### PR TITLE
Helm 4 upgrade

### DIFF
--- a/.github/workflows/docker_build_push.yaml
+++ b/.github/workflows/docker_build_push.yaml
@@ -12,7 +12,8 @@ jobs:
       max-parallel: 1
       matrix:
         include: # Full semver versions
-          - helm_version: 3.19.0
+          - helm_version: 3.21.0
+          - helm_version: 4.2.0
             is_latest: true
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,18 @@
-ARG HELM_VERSION=3.15.4
-ARG CHECKOV_VERSION=3.2.268
-ARG OPA_VERSION=0.69.0
-ARG RUN_IMG=debian:12.7-slim
+ARG HELM_VERSION=4.2.0
+ARG CHECKOV_VERSION=3.2.530
+ARG RUN_IMG=debian:13.5-slim
 ARG USER=massdriver
 ARG UID=10001
 
 FROM ${RUN_IMG} AS build
 ARG HELM_VERSION
 ARG CHECKOV_VERSION
-ARG OPA_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y curl unzip make jq && \
     rm -rf /var/lib/apt/lists/* && \
     curl -s https://api.github.com/repos/massdriver-cloud/xo/releases/latest | jq -r '.assets[] | select(.name | contains("linux-amd64")) | .browser_download_url' | xargs curl -sSL -o xo.tar.gz && tar -xvf xo.tar.gz -C /tmp && mv /tmp/xo /usr/local/bin/ && rm *.tar.gz && \
-    curl -sSL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz > helm.tar.gz && tar -xzf helm.tar.gz -C /usr/local/bin && \
-    curl -sSL https://openpolicyagent.org/downloads/v${OPA_VERSION}/opa_linux_amd64_static > /usr/local/bin/opa && chmod a+x /usr/local/bin/opa && \
+    curl -sSL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz > helm.tar.gz && tar -xzf helm.tar.gz -C /usr/local/bin --strip-components=1 linux-amd64/helm && \
     curl -sSL https://github.com/bridgecrewio/checkov/releases/download/${CHECKOV_VERSION}/checkov_linux_X86_64.zip > checkov.zip && unzip checkov.zip && mv dist/checkov /usr/local/bin/ && rm *.zip && \
     curl -sSL https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_linux_amd64 > /usr/local/bin/yq && chmod a+x /usr/local/bin/yq
 
@@ -23,21 +20,27 @@ FROM ${RUN_IMG}
 ARG USER
 ARG UID
 
-RUN apt update && apt install -y ca-certificates jq && \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates jq && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p -m 777 /massdriver
 
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --uid $UID \
-    $USER
-RUN chown -R $USER:$USER /massdriver
-USER $USER
+RUN useradd \
+    --create-home \
+    --shell /bin/bash \
+    --uid ${UID} \
+    ${USER} && \
+    chown -R ${USER}:${USER} /massdriver
 
-COPY --from=build /usr/local/bin/* /usr/local/bin/
-COPY entrypoint.sh /usr/local/bin/
+COPY --from=build /usr/local/bin/xo /usr/local/bin/xo
+COPY --from=build /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=build /usr/local/bin/checkov /usr/local/bin/checkov
+COPY --from=build /usr/local/bin/yq /usr/local/bin/yq
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+USER ${USER}
 
 ENV MASSDRIVER_PROVISIONER=helm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG HELM_VERSION
 ARG CHECKOV_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install -y curl unzip make jq && \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl unzip jq && \
     rm -rf /var/lib/apt/lists/* && \
     curl -s https://api.github.com/repos/massdriver-cloud/xo/releases/latest | jq -r '.assets[] | select(.name | contains("linux-amd64")) | .browser_download_url' | xargs curl -sSL -o xo.tar.gz && tar -xvf xo.tar.gz -C /tmp && mv /tmp/xo /usr/local/bin/ && rm *.tar.gz && \
     curl -sSL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz > helm.tar.gz && tar -xzf helm.tar.gz -C /usr/local/bin --strip-components=1 linux-amd64/helm && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,16 +35,16 @@ jq_bool_default() {
 evaluate_checkov() {
     if [ "$checkov_enabled" = "true" ]; then
         echo "Evaluating Checkov policies..."
-        checkov_flags=""
+        checkov_flags=()
 
         if [ "$checkov_quiet" = "true" ]; then
-            checkov_flags+=" --quiet"
+            checkov_flags+=(--quiet)
         fi
         if [ "$checkov_halt_on_failure" = "false" ]; then
-            checkov_flags+=" --soft-fail"
+            checkov_flags+=(--soft-fail)
         fi
 
-        checkov -d . --framework helm --var-file params_values.yaml --var-file connections_values.yaml --var-file envs_values.yaml --var-file secrets_values.yaml $checkov_flags
+        checkov -d . --framework helm --var-file params_values.yaml --var-file connections_values.yaml --var-file envs_values.yaml --var-file secrets_values.yaml "${checkov_flags[@]}"
     fi
 }
 
@@ -69,36 +69,45 @@ chart_name=$(jq -r '.chart.name // empty' "$config_path")
 chart_version=$(jq -r '.chart.version // empty' "$config_path")
 chart_oci=$(jq -r '.chart.oci // empty' "$config_path")
 
-# Extract auth
-# Try to get Kubernetes authentication from config.json, then fall back to connections.json
-k8s_auth=$(jq -r '.kubernetes_cluster // empty' "$config_path" 2>/dev/null || true)
+# ---------------------------------------------------------------------------
+# Kubernetes authentication
+#
+# Token auth is resolved from the kubernetes_cluster connection's
+# `authentication` block, with config.kubernetes_cluster overlaid on top per
+# field. This gives a "connection default, config override" model: provide the
+# whole credential through the connection, override a single field, or remap a
+# differently-shaped resource type entirely through config.
+#
+# Field resolution (config overlays the connection per-field via deep merge):
+#   1. config.kubernetes_cluster.authentication            (override, top-level)
+#   2. connections.kubernetes_cluster.authentication       (connection, top-level) } first
+#   3. connections.kubernetes_cluster.data.authentication  (legacy conn, .data)    } found
+#
+# The `.data` sub-block fallback is only honored on the connection side for
+# backwards compatibility; config overrides use the canonical top-level shape.
+# ---------------------------------------------------------------------------
 
-if [ -z "$k8s_auth" ]; then
-  k8s_auth=$(jq -r '.kubernetes_cluster // empty' "$connections_path" 2>/dev/null || true)
-fi
+auth=$(jq -s '
+    (.[1].kubernetes_cluster.authentication // .[1].kubernetes_cluster.data.authentication // {}) as $conn
+  | (.[0].kubernetes_cluster.authentication // {})                                            as $cfg
+  | $conn * $cfg
+' "$config_path" "$connections_path")
 
-# Check if k8s_auth is still empty, and exit since we don't have auth info
-if [ -z "$k8s_auth" ]; then
-  echo -e "${RED}Error: No kubernetes credentials found. Please refer to the provisioner documentation for specifying kubernetes credentials.${NC}"
-  exit 1
-fi
-
-# Extract fields from kubernetes_cluster and validate they are not empty
-k8s_apiserver=$(echo "$k8s_auth" | jq -r '.authentication.cluster.server // .data.authentication.cluster.server // empty')
-k8s_token=$(echo "$k8s_auth" | jq -r '.authentication.user.token // .data.authentication.user.token // empty')
+k8s_apiserver=$(echo "$auth" | jq -r '.cluster.server // empty')
+k8s_token=$(echo "$auth" | jq -r '.user.token // empty')
 k8s_cacert_file="${entrypoint_dir}/ca_cert.pem"
-echo "$k8s_auth" | jq -r '.authentication.cluster."certificate-authority-data" // .data.authentication.cluster."certificate-authority-data" // empty' | base64 -d > "$k8s_cacert_file"
+echo "$auth" | jq -r '.cluster."certificate-authority-data" // empty' | base64 -d > "$k8s_cacert_file"
 
 if [ -z "$k8s_apiserver" ]; then
-  echo -e "${RED}Error: Missing required field "server" in kubernetes credentials. Please refer to the provisioner documentation for specifying kubernetes credentials.${NC}"
+  echo -e "${RED}Error: Missing required field \"server\" in kubernetes credentials. Please refer to the provisioner documentation for specifying kubernetes credentials.${NC}"
   exit 1
 fi
 if [ -z "$k8s_token" ]; then
-  echo -e "${RED}Error: Missing required field "token" in kubernetes credentials. Please refer to the provisioner documentation for specifying kubernetes credentials.${NC}"
+  echo -e "${RED}Error: Missing required field \"token\" in kubernetes credentials. Please refer to the provisioner documentation for specifying kubernetes credentials.${NC}"
   exit 1
 fi
 if [ ! -s "$k8s_cacert_file" ]; then
-    echo -e "${RED}Error: Missing required field "certificate-authority-data" in kubernetes credentials. Please refer to the provisioner documentation for specifying kubernetes credentials.${NC}"
+    echo -e "${RED}Error: Missing required field \"certificate-authority-data\" in kubernetes credentials. Please refer to the provisioner documentation for specifying kubernetes credentials.${NC}"
     exit 1
 fi
 
@@ -240,7 +249,9 @@ case "$MASSDRIVER_DEPLOYMENT_ACTION" in
     ;;
 
   decommission)
-    helm_command=(uninstall "$release_name" --namespace "$namespace")
+    # --ignore-not-found so a missing release doesn't abort the run before the
+    # resource-cleanup loop below gets a chance to delete published resources.
+    helm_command=(uninstall "$release_name" --namespace "$namespace" --ignore-not-found)
     ;;
 
   *)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 set -euo pipefail
+# Unmatched globs expand to nothing instead of the literal pattern, so the
+# artifact_*.jq / resource_*.jq loops below simply skip when no files match.
+shopt -s nullglob
 
 # Define colors
 RED='\033[0;31m'
+YELLOW='\033[0;33m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color (reset)
 
@@ -48,7 +52,7 @@ evaluate_checkov() {
 name_prefix=$(jq -r '.md_metadata.name_prefix' "$params_path")
 release_name=$(jq -r --arg name_prefix "$name_prefix" '.release_name // $name_prefix' "$config_path")
 namespace=$(jq -r '.namespace // "default"' "$config_path")
-debug=$(jq_bool_default '.debug' true "$config_path")
+debug=$(jq_bool_default '.debug' false "$config_path")
 timeout=$(jq -r '.timeout // empty' "$config_path")
 wait=$(jq_bool_default '.wait' true "$config_path")
 wait_for_jobs=$(jq_bool_default '.wait_for_jobs' true "$config_path")
@@ -80,10 +84,10 @@ if [ -z "$k8s_auth" ]; then
 fi
 
 # Extract fields from kubernetes_cluster and validate they are not empty
-k8s_apiserver=$(echo "$k8s_auth" | jq -r '.data.authentication.cluster.server // empty')
-k8s_token=$(echo "$k8s_auth" | jq -r '.data.authentication.user.token // empty')
+k8s_apiserver=$(echo "$k8s_auth" | jq -r '.authentication.cluster.server // .data.authentication.cluster.server // empty')
+k8s_token=$(echo "$k8s_auth" | jq -r '.authentication.user.token // .data.authentication.user.token // empty')
 k8s_cacert_file="${entrypoint_dir}/ca_cert.pem"
-echo "$k8s_auth" | jq -r '.data.authentication.cluster."certificate-authority-data" // empty' | base64 -d > "$k8s_cacert_file"
+echo "$k8s_auth" | jq -r '.authentication.cluster."certificate-authority-data" // .data.authentication.cluster."certificate-authority-data" // empty' | base64 -d > "$k8s_cacert_file"
 
 if [ -z "$k8s_apiserver" ]; then
   echo -e "${RED}Error: Missing required field "server" in kubernetes credentials. Please refer to the provisioner documentation for specifying kubernetes credentials.${NC}"
@@ -182,61 +186,61 @@ else
 fi
 
 # Build values files list
-values_files=""
+values_files=()
 
 # Add static values.yaml if it exists (not for local charts which use their own)
 if [ -f values.yaml ] && [ "$chart_type" != "local" ]; then
-    values_files+=" -f values.yaml"
+    values_files+=(-f values.yaml)
 fi
 
-values_files+=" -f connections_values.yaml -f params_values.yaml -f envs_values.yaml -f secrets_values.yaml"
+values_files+=(-f connections_values.yaml -f params_values.yaml -f envs_values.yaml -f secrets_values.yaml)
 
-# extract helm args from config
-helm_args=""
+# Extract helm args from config
+helm_args=()
 
 if [ "$debug" = "true" ]; then
-    helm_args+=" --debug"
+    helm_args+=(--debug)
 fi
 
 if [ "$wait" = "true" ]; then
-    helm_args+=" --wait"
+    helm_args+=(--wait)
 fi
 
 if [ "$wait_for_jobs" = "true" ] && [ "$MASSDRIVER_DEPLOYMENT_ACTION" != "decommission" ]; then
-    helm_args+=" --wait-for-jobs"
+    helm_args+=(--wait-for-jobs)
 fi
 
 if [ -n "$timeout" ]; then
-    helm_args+=" --timeout $timeout"
+    helm_args+=(--timeout "$timeout")
 fi
 
 if [ "$skip_crds" = "true" ] && [ "$MASSDRIVER_DEPLOYMENT_ACTION" != "decommission" ]; then
-    helm_args+=" --skip-crds"
+    helm_args+=(--skip-crds)
+fi
+
+# Add version specification for remote and OCI charts
+chart_args=()
+if [ "$chart_type" != "local" ] && [ -n "$chart_version" ]; then
+    chart_args+=(--version "$chart_version")
 fi
 
 # Determine Helm command based on deployment action
-helm_command=""
-chart_args=""
-
-# Add version specification for remote and OCI charts
-if [ "$chart_type" != "local" ] && [ -n "$chart_version" ]; then
-    chart_args="--version $chart_version"
-fi
+helm_command=()
 
 case "$MASSDRIVER_DEPLOYMENT_ACTION" in
 
   plan)
     evaluate_checkov
-    helm_command="upgrade $release_name $chart_reference --dry-run --install --namespace $namespace --create-namespace $values_files $chart_args"
+    helm_command=(upgrade "$release_name" "$chart_reference" --dry-run --install --namespace "$namespace" --create-namespace "${values_files[@]}" "${chart_args[@]}")
     ;;
 
   provision)
     evaluate_checkov
-    helm_command="upgrade $release_name $chart_reference --install --namespace $namespace --create-namespace $values_files $chart_args"
+    helm_command=(upgrade "$release_name" "$chart_reference" --install --namespace "$namespace" --create-namespace "${values_files[@]}" "${chart_args[@]}")
     ;;
 
   decommission)
-    helm_command="uninstall $release_name --namespace $namespace"
+    helm_command=(uninstall "$release_name" --namespace "$namespace")
     ;;
 
   *)
@@ -246,23 +250,32 @@ case "$MASSDRIVER_DEPLOYMENT_ACTION" in
 
 esac
 
-helm $helm_command $helm_args --kube-apiserver $k8s_apiserver --kube-token $k8s_token --kube-ca-file "$k8s_cacert_file"
+helm "${helm_command[@]}" "${helm_args[@]}" --kube-apiserver "$k8s_apiserver" --kube-token "$k8s_token" --kube-ca-file "$k8s_cacert_file"
 
 # Clean up temporary repository if we added one (only for remote charts)
 if [ "$chart_type" = "remote" ]; then
     helm repo remove temp-repo 2>/dev/null || true
 fi
 
-# Create artifacts if deployment action is 'provision'
+# Publish or delete resources based on deployment action
 case "$MASSDRIVER_DEPLOYMENT_ACTION" in
-  provision )
-    helm --kube-apiserver $k8s_apiserver --kube-token $k8s_token --kube-ca-file "$k8s_cacert_file" get manifest $release_name --namespace $namespace | yq ea -o=json '[.]' > outputs.json
-    jq -s '{params:.[0],connections:.[1],envs:.[2],secrets:.[3],outputs:.[4]}' "$params_path" "$connections_path" "$envs_path" "$secrets_path" outputs.json > artifact_inputs.json
-    for artifact_file in artifact_*.jq; do
-        [ -f "$artifact_file" ] || break
-        field=$(echo "$artifact_file" | sed 's/^artifact_\(.*\).jq$/\1/')
-        echo "Creating artifact for field $field"
-        jq -f "$artifact_file" artifact_inputs.json | xo artifact publish -d "$field" -n "Artifact $field for helm release $release_name" -f -
+  provision)
+    helm --kube-apiserver "$k8s_apiserver" --kube-token "$k8s_token" --kube-ca-file "$k8s_cacert_file" get manifest "$release_name" --namespace "$namespace" | yq ea -o=json '[.]' > outputs.json
+    jq -s '{params:.[0],connections:.[1],envs:.[2],secrets:.[3],outputs:.[4]}' "$params_path" "$connections_path" "$envs_path" "$secrets_path" outputs.json > resource_inputs.json
+    for resource_file in artifact_*.jq resource_*.jq; do
+        [ -f "$resource_file" ] || continue
+        field=$(echo "$resource_file" | sed -E 's/^(artifact|resource)_(.*)\.jq$/\2/')
+        echo "Creating resource field $field"
+        jq -f "$resource_file" resource_inputs.json | xo resource publish -d "$field" -n "Resource $field for helm release $release_name" -f -
+    done
+    ;;
+
+  decommission)
+    for resource_file in artifact_*.jq resource_*.jq; do
+        [ -f "$resource_file" ] || continue
+        field=$(echo "$resource_file" | sed -E 's/^(artifact|resource)_(.*)\.jq$/\2/')
+        echo "Deleting resource field $field"
+        xo resource delete -d "$field" || echo -e "${YELLOW}Warning: failed to delete resource for field $field. Continuing decommission.${NC}"
     done
     ;;
 esac

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -265,7 +265,7 @@ case "$MASSDRIVER_DEPLOYMENT_ACTION" in
     for resource_file in artifact_*.jq resource_*.jq; do
         [ -f "$resource_file" ] || continue
         field=$(echo "$resource_file" | sed -E 's/^(artifact|resource)_(.*)\.jq$/\2/')
-        echo "Creating resource field $field"
+        echo -e "\nCreating resource \"$MASSDRIVER_INSTANCE_ID-$field\" in Massdriver..."
         jq -f "$resource_file" resource_inputs.json | xo resource publish -d "$field" -n "Resource $field for helm release $release_name" -f -
     done
     ;;
@@ -274,7 +274,7 @@ case "$MASSDRIVER_DEPLOYMENT_ACTION" in
     for resource_file in artifact_*.jq resource_*.jq; do
         [ -f "$resource_file" ] || continue
         field=$(echo "$resource_file" | sed -E 's/^(artifact|resource)_(.*)\.jq$/\2/')
-        echo "Deleting resource field $field"
+        echo -e "\nDeleting resource \"$MASSDRIVER_INSTANCE_ID-$field\" from Massdriver..."
         xo resource delete -d "$field" || echo -e "${YELLOW}Warning: failed to delete resource for field $field. Continuing decommission.${NC}"
     done
     ;;


### PR DESCRIPTION
## Summary of changes

### Toolchain / image (`Dockerfile`)
- **Helm 3.15.4 → 4.2.0**, **Checkov 3.2.268 → 3.2.530**, **base image debian 12.7 → 13.5-slim**.
- Switched the runtime stage to explicit per-binary `COPY` lines (`xo`, `helm`, `checkov`, `yq`) instead of a `bin/*` wildcard, and fixed the Helm tarball extraction to land the binary directly at `/usr/local/bin/helm` (`--strip-components=1 linux-amd64/helm`). The old wildcard COPY had been silently flattening the `linux-amd64/` dir; the explicit list required making the path correct.
- Hardened the build: `useradd` with home/shell, `--no-install-recommends`, `DEBIAN_FRONTEND=noninteractive`.

### CI (`.github/workflows/docker_build_push.yaml`)
- Build matrix now publishes **Helm 3.21.0** and **Helm 4.2.0**, with **4.2.0 tagged `latest`**. ⚠️ Note: `latest` now resolves to a Helm 4 image — a major-version bump for anyone tracking that tag.

### Provisioner logic (`entrypoint.sh`)
- **Kubernetes authentication**: token auth is resolved from the `kubernetes_cluster` connection's `authentication` block, with `config.kubernetes_cluster` overlaid on top per-field (deep merge) — a "connection default, config override" model. You can override a single field, or remap a differently-shaped resource type entirely, through config.
- **Auth back-compat**: the connection lookup prefers the top-level `authentication` block and falls back to the legacy `.data.authentication` sub-block (deprecated, may be removed). The `.data` fallback applies only to the connection; config overrides use the canonical top-level shape.
- **Resource model migration**: `xo artifact publish` → `xo resource publish`; loops now match both `artifact_*.jq` and `resource_*.jq`; added a **decommission** branch that runs `xo resource delete` per field (warns and continues on failure, with `helm uninstall --ignore-not-found` so a missing release doesn't skip cleanup).
- **Array-based command construction**: `values_files`, `helm_args`, `chart_args`, and `helm_command` are now bash arrays, fully quoted at the call site — eliminates word-splitting fragility. Quoted the kube-auth flags everywhere.
- **Loop hardening**: `shopt -s nullglob` + `continue` so the `.jq` loops cleanly skip when no files match.
- **`debug` now defaults to `false`** (was `true`) — reduces default Helm log noise.
- Added a `YELLOW` color for decommission warnings.

### Notes for reviewers
- The `xo artifact → resource` switch assumes the platform's artifact/resource model unification is live (same assumption as the Bicep provisioner).
- Helm 4's `--wait` now fails fast on a failed resource instead of waiting out the timeout — charts that previously "passed" only via timeout may now surface failures.